### PR TITLE
feat: Changed scope of $remember

### DIFF
--- a/src/Flarum.php
+++ b/src/Flarum.php
@@ -23,7 +23,7 @@ class Flarum
     public $api;
 
     /* @var bool Should the login be remembered (this equals to 5 years remember from last usage)? If false, token will be remembered only for 1 hour */
-    private $remember;
+    public $remember;
 
     /* @var string Random token to create passwords */
     public $password_token;


### PR DESCRIPTION
I figured since some frameworks include the use of controllers to settle Login/Register/Logout/Update requests all in one, then I think it's best for users to be able to set the `$remember` property dynamically.

Such as instantiating the `Flarum` class in the constructor function, and then dynamically set the `$remember` boolean based on the individual methods (login/register) in the same controller.

Example:
```
function __construct() {
  $flarum = new Flarum($options);
}

public function login($request) {
  $flarum->remember = $request->remember // true or false
}
```