### PR TITLE
Support Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": ">=7.3",
         "ext-json": "*",
         "delight-im/cookie": "^3",
-        "illuminate/support": "^8|^9",
+        "illuminate/support": "^8|^9|^10",
         "maicol07/flarum-api-client": "^1",
         "mistic100/php-hooks": "^0"
     },


### PR DESCRIPTION
Add support for Laravel 10 by adding v10 to illuminate/support

There is also similar PR in flarum-api-client package which should also be merged before you can use this package in Laravel 10 projects.